### PR TITLE
Fix compile error

### DIFF
--- a/src/lopcodes.h
+++ b/src/lopcodes.h
@@ -235,7 +235,7 @@ OP_FLVM
 } OpCode;
 
 
-#define NUM_OPCODES	(cast(int, OP_EXTRAARG) + 1)
+#define NUM_OPCODES	(cast(int, OP_FLVM) + 1)
 
 
 


### PR DESCRIPTION
NUM_OPCODES macro should use the last opcode in OpCode enum.